### PR TITLE
Fully untangling OpenCV dependency

### DIFF
--- a/edge_impulse_linux/image.py
+++ b/edge_impulse_linux/image.py
@@ -1,13 +1,23 @@
 #!/usr/bin/env python
 
 import numpy as np
-import cv2
+opencv_installed = True
+
+try:
+    import cv2
+except ModuleNotFoundError as e: # can alternatively drop the boolean check for NameError exception when cv2 is called
+    opencv_installed = False
+
+
 from edge_impulse_linux.runner import ImpulseRunner
 import math
 import psutil
 
 class ImageImpulseRunner(ImpulseRunner):
     def __init__(self, model_path: str):
+        if not opencv_installed:  # can alternatively drop the boolean check for NameError exception when cv2 is called
+            raise Exception("OpenCV Not found. To use ImageImpulseRunner, ensure opencv-python>=4.5.1.48 is installed.")
+        
         super(ImageImpulseRunner, self).__init__(model_path)
         self.closed = True
         self.labels = []
@@ -16,9 +26,11 @@ class ImageImpulseRunner(ImpulseRunner):
         self.isGrayscale = False
 
     def init(self):
+
+
         model_info = super(ImageImpulseRunner, self).init()
-        width = model_info['model_parameters']['image_input_width'];
-        height = model_info['model_parameters']['image_input_height'];
+        width = model_info['model_parameters']['image_input_width']
+        height = model_info['model_parameters']['image_input_height']
 
         if width == 0 or height == 0:
             raise Exception('Model file "' + self._model_path + '" is not suitable for image recognition')


### PR DESCRIPTION
OpenCV was recently removed from requirements.txt, which in theory enables the use of this package without OpenCV through audio and custom impulse implementations. However, the cv2 dependency was not fully untangled:

```python
from edge_impulse_linux.audio import AudioImpulseRunner

Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/home/tgw/.local/lib/python3.9/site-packages/edge_impulse_linux/__init__.py", line 3, in <module>
    from edge_impulse_linux import image
  File "/home/tgw/.local/lib/python3.9/site-packages/edge_impulse_linux/image.py", line 5, in <module>
    import cv2
ModuleNotFoundError: No module named 'cv2'

```

```python
from edge_impulse_linux.runner import ImpulseRunner as ImpulseRunner
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/home/tgw/.local/lib/python3.9/site-packages/edge_impulse_linux/__init__.py", line 3, in <module>
    from edge_impulse_linux import image
  File "/home/tgw/.local/lib/python3.9/site-packages/edge_impulse_linux/image.py", line 5, in <module>
    import cv2
ModuleNotFoundError: No module named 'cv2'

```

My solution adds a try/catch into image.py:

```python
...
try:
    import cv2
except ModuleNotFoundError as e:
    opencv_installed = False

class ImageImpulseRunner(ImpulseRunner):
    def __init__(self, model_path: str):
        if not opencv_installed:
            raise Exception("OpenCV Not found. To use ImageImpulseRunner, ensure opencv-python>=4.5.1.48 is installed.")
...
```

An alternative solution could also be:

```python
...
try:
    import cv2
...
```