### PR TITLE
Fix runner data buffer 

### DIFF
--- a/edge_impulse_linux/runner.py
+++ b/edge_impulse_linux/runner.py
@@ -87,9 +87,14 @@ class ImpulseRunner:
 
         t_sent_msg = now()
 
-        # i'm not sure if this is right, we should switch to async i/o for this like in Node
-        # I think that would perform better
-        data = self._client.recv(1 * 1024 * 1024)
+        data = b""
+        while True:
+            chunk = self._client.recv(1024)
+            # end chunk has \x00 in the end
+            if chunk[-1] == 0:
+                data = data + chunk[:-1]
+                break
+            data = data + chunk
 
         t_received_msg = now()
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ numpy>=1.19
 PyAudio==0.2.11
 psutil>=5.8.0
 edge_impulse_linux
+six==1.16.0

--- a/setup.cfg
+++ b/setup.cfg
@@ -16,6 +16,4 @@ classifiers =
 [options]
 packages = find:
 python_requires = >=3.6
-install_requires =
-    numpy>=1.19
-    psutil>=5.8.0
+install_requires = file: requirements.txt


### PR DESCRIPTION
If the amount of data received from .eim in certain cases does not fit in a single packet (1024 * 1024 bytes), it will not be parsed as valid json, and therefore the user will see
**No data or corrupt data received error.**